### PR TITLE
Restore option to disable merge info

### DIFF
--- a/src/main/java/org/sonar/plugins/scm/svn/AnnotationHandler.java
+++ b/src/main/java/org/sonar/plugins/scm/svn/AnnotationHandler.java
@@ -30,7 +30,12 @@ import java.util.List;
 
 public class AnnotationHandler implements ISVNAnnotateHandler {
 
+  private boolean useMergeHistory;
   private List<BlameLine> lines = new ArrayList<BlameLine>();
+
+  public AnnotationHandler(boolean useMergeHistory) {
+    this.useMergeHistory = useMergeHistory;
+  }
 
   @Override
   public void handleEOF() {
@@ -45,7 +50,11 @@ public class AnnotationHandler implements ISVNAnnotateHandler {
   @Override
   public void handleLine(Date date, long revision, String author, String line, Date mergedDate,
     long mergedRevision, String mergedAuthor, String mergedPath, int lineNumber) throws SVNException {
-    lines.add(new BlameLine().date(mergedDate).revision(Long.toString(mergedRevision)).author(mergedAuthor));
+    if (useMergeHistory) {
+      lines.add(new BlameLine().date(mergedDate).revision(Long.toString(mergedRevision)).author(mergedAuthor));
+    } else {
+      lines.add(new BlameLine().date(date).revision(Long.toString(revision)).author(author));
+    }
   }
 
   @Override

--- a/src/main/java/org/sonar/plugins/scm/svn/SvnBlameCommand.java
+++ b/src/main/java/org/sonar/plugins/scm/svn/SvnBlameCommand.java
@@ -72,7 +72,8 @@ public class SvnBlameCommand extends BlameCommand {
   private void blame(SVNClientManager clientManager, FileSystem fs, InputFile inputFile, BlameOutput output) {
     String filename = inputFile.relativePath();
 
-    AnnotationHandler handler = new AnnotationHandler();
+    boolean useMergeHistory = configuration.useMergeHistory();
+    AnnotationHandler handler = new AnnotationHandler(useMergeHistory);
     try {
       SVNStatusClient statusClient = clientManager.getStatusClient();
       try {
@@ -95,7 +96,7 @@ public class SvnBlameCommand extends BlameCommand {
       }
       SVNLogClient logClient = clientManager.getLogClient();
       logClient.setDiffOptions(new SVNDiffOptions(true, true, true));
-      logClient.doAnnotate(inputFile.file(), SVNRevision.UNDEFINED, SVNRevision.create(1), SVNRevision.BASE, true, true, handler, null);
+      logClient.doAnnotate(inputFile.file(), SVNRevision.UNDEFINED, SVNRevision.create(1), SVNRevision.BASE, true, useMergeHistory, handler, null);
     } catch (SVNException e) {
       throw new IllegalStateException("Error when executing blame for file " + filename, e);
     }

--- a/src/main/java/org/sonar/plugins/scm/svn/SvnConfiguration.java
+++ b/src/main/java/org/sonar/plugins/scm/svn/SvnConfiguration.java
@@ -38,6 +38,7 @@ public class SvnConfiguration implements BatchComponent {
   private static final String CATEGORY_SVN = "SVN";
   public static final String USER_PROP_KEY = "sonar.svn.username";
   public static final String PASSWORD_PROP_KEY = "sonar.svn.password.secured";
+  public static final String USE_MERGE_HISTORY_KEY = "sonar.svn.use_merge_history";
   private final Settings settings;
 
   public SvnConfiguration(Settings settings) {
@@ -63,6 +64,16 @@ public class SvnConfiguration implements BatchComponent {
         .category(CoreProperties.CATEGORY_SCM)
         .subCategory(CATEGORY_SVN)
         .index(1)
+        .build(),
+      PropertyDefinition.builder(USE_MERGE_HISTORY_KEY)
+        .name("Use merge history for blame")
+        .description("Use merge history to get real author of a modification instead of committer of the merge.")
+        .type(PropertyType.BOOLEAN)
+        .defaultValue("true")
+        .onQualifiers(Qualifiers.PROJECT)
+        .category(CoreProperties.CATEGORY_SCM)
+        .subCategory(CATEGORY_SVN)
+        .index(2)
         .build());
   }
 
@@ -76,4 +87,7 @@ public class SvnConfiguration implements BatchComponent {
     return settings.getString(PASSWORD_PROP_KEY);
   }
 
+  public boolean useMergeHistory() {
+    return settings.getBoolean(USE_MERGE_HISTORY_KEY);
+  }
 }

--- a/src/test/java/org/sonar/plugins/scm/svn/SvnBlameCommandTest.java
+++ b/src/test/java/org/sonar/plugins/scm/svn/SvnBlameCommandTest.java
@@ -115,7 +115,10 @@ public class SvnBlameCommandTest {
     BlameOutput blameResult = mock(BlameOutput.class);
     when(input.filesToBlame()).thenReturn(Arrays.<InputFile>asList(inputFile));
 
-    new SvnBlameCommand(mock(SvnConfiguration.class)).blame(input, blameResult);
+    final SvnConfiguration configuration = mock(SvnConfiguration.class);
+    when(configuration.useMergeHistory()).thenReturn(true);
+
+    new SvnBlameCommand(configuration).blame(input, blameResult);
     ArgumentCaptor<List> captor = ArgumentCaptor.forClass(List.class);
     verify(blameResult).blameResult(eq(inputFile), captor.capture());
     List<BlameLine> result = captor.getValue();
@@ -192,7 +195,10 @@ public class SvnBlameCommandTest {
     BlameOutput blameResult = mock(BlameOutput.class);
     when(input.filesToBlame()).thenReturn(Arrays.<InputFile>asList(inputFile));
 
-    new SvnBlameCommand(mock(SvnConfiguration.class)).blame(input, blameResult);
+    final SvnConfiguration configuration = mock(SvnConfiguration.class);
+    when(configuration.useMergeHistory()).thenReturn(true);
+
+    new SvnBlameCommand(configuration).blame(input, blameResult);
     ArgumentCaptor<List> captor = ArgumentCaptor.forClass(List.class);
     verify(blameResult).blameResult(eq(inputFile), captor.capture());
     List<BlameLine> result = captor.getValue();
@@ -227,6 +233,61 @@ public class SvnBlameCommandTest {
       new BlameLine().date(commitDate).revision("2").author("dgageot"),
       new BlameLine().date(commitDate).revision("2").author("dgageot"),
       new BlameLine().date(commitDate).revision("2").author("dgageot"));
+  }
+
+  @Test
+  public void testParsingOfOutputWithMergeHistoryDisabled() throws Exception {
+    File repoDir = unzip("repo-svn-with-merge.zip");
+
+    String scmUrl = "file:///" + unixPath(new File(repoDir, "repo-svn"));
+    File baseDir = new File(checkout(scmUrl), "dummy-svn/trunk");
+
+    when(fs.baseDir()).thenReturn(baseDir);
+    DefaultInputFile inputFile = new DefaultInputFile("foo", DUMMY_JAVA)
+            .setLines(27)
+            .setModuleBaseDir(baseDir.toPath());
+
+    BlameOutput blameResult = mock(BlameOutput.class);
+    when(input.filesToBlame()).thenReturn(Arrays.<InputFile>asList(inputFile));
+
+    final SvnConfiguration configuration = mock(SvnConfiguration.class);
+    when(configuration.useMergeHistory()).thenReturn(false);
+
+    new SvnBlameCommand(configuration).blame(input, blameResult);
+    ArgumentCaptor<List> captor = ArgumentCaptor.forClass(List.class);
+    verify(blameResult).blameResult(eq(inputFile), captor.capture());
+    List<BlameLine> result = captor.getValue();
+    assertThat(result).hasSize(27);
+    Date commitDate = new Date(1342691097393L);
+    Date revision7Date = new Date(1415262286278L);
+    assertThat(result).containsExactly(
+            new BlameLine().date(commitDate).revision("2").author("dgageot"),
+            new BlameLine().date(revision7Date).revision("7").author("merge-bot"),
+            new BlameLine().date(commitDate).revision("2").author("dgageot"),
+            new BlameLine().date(commitDate).revision("2").author("dgageot"),
+            new BlameLine().date(commitDate).revision("2").author("dgageot"),
+            new BlameLine().date(commitDate).revision("2").author("dgageot"),
+            new BlameLine().date(commitDate).revision("2").author("dgageot"),
+            new BlameLine().date(commitDate).revision("2").author("dgageot"),
+            new BlameLine().date(commitDate).revision("2").author("dgageot"),
+            new BlameLine().date(commitDate).revision("2").author("dgageot"),
+            new BlameLine().date(commitDate).revision("2").author("dgageot"),
+            new BlameLine().date(commitDate).revision("2").author("dgageot"),
+            new BlameLine().date(commitDate).revision("2").author("dgageot"),
+            new BlameLine().date(commitDate).revision("2").author("dgageot"),
+            new BlameLine().date(commitDate).revision("2").author("dgageot"),
+            new BlameLine().date(commitDate).revision("2").author("dgageot"),
+            new BlameLine().date(commitDate).revision("2").author("dgageot"),
+            new BlameLine().date(commitDate).revision("2").author("dgageot"),
+            new BlameLine().date(commitDate).revision("2").author("dgageot"),
+            new BlameLine().date(commitDate).revision("2").author("dgageot"),
+            new BlameLine().date(commitDate).revision("2").author("dgageot"),
+            new BlameLine().date(commitDate).revision("2").author("dgageot"),
+            new BlameLine().date(commitDate).revision("2").author("dgageot"),
+            new BlameLine().date(revision7Date).revision("7").author("merge-bot"),
+            new BlameLine().date(commitDate).revision("2").author("dgageot"),
+            new BlameLine().date(commitDate).revision("2").author("dgageot"),
+            new BlameLine().date(commitDate).revision("2").author("dgageot"));
   }
 
   @Test


### PR DESCRIPTION
Add support for option `sonar.svn.use_merge_history` from previous svn plugin. By default merge history is used.